### PR TITLE
security_policy.conf: Add /usr/palm/public/

### DIFF
--- a/files/launch/security_policy.conf
+++ b/files/launch/security_policy.conf
@@ -9,7 +9,9 @@
 8/path=/usr/palm/license/
 9/path=/usr/palm/plugins/license/
 10/path=/usr/palm/applications/
-size=10
+11/path=/usr/palm/public/
+12/path=/usr/palm/services/
+size=12
 
 [Trusted]
 1/path=/media/


### PR DESCRIPTION
So the account template icons in com.palm.app.accounts will work again.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>