### PR TITLE
WAM: Use Prelude as default font

### DIFF
--- a/src/core/web_page_base.cc
+++ b/src/core/web_page_base.cc
@@ -439,7 +439,7 @@ void WebPageBase::SetBackgroundColorOfBody(const std::string& color) {
 }
 
 std::string WebPageBase::DefaultFont() {
-  std::string default_font = "LG Display-Regular";
+  std::string default_font = "Prelude";
   std::string language;
   std::string country;
   GetSystemLanguage(language);


### PR DESCRIPTION
Bring back our beloved Prelude font for web apps :)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>