### PR TITLE
WebPageBlink: keep same window type when creating additional windows

### DIFF
--- a/src/platform/webengine/web_page_blink.cc
+++ b/src/platform/webengine/web_page_blink.cc
@@ -1252,7 +1252,8 @@ WebView* WebPageBlink::CreateWindow(const std::string& newUrl, std::unique_ptr<W
 
   // Create a new webApp instance for this page
   WebAppManager *webAppMgr = WebAppManager::Instance();
-  webAppMgr->CreateWindowForAppPage(kWtCard, app_desc_, "{}", app_id_, newPage);
+  webAppMgr->CreateWindowForAppPage(webAppMgr->WindowTypeFromString(app_desc_->DefaultWindowType()), 
+                                    app_desc_, "{}", app_id_, newPage);
   
   return newPage->PageView();
 }


### PR DESCRIPTION
If an app has a specific "defaultWindowType" in appinfo.json, if should be kept when opening an additional window.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>